### PR TITLE
[add]ジャンケン画像が大きすぎる問題と下に寄っている問題の改善

### DIFF
--- a/MyJanken/MyJanken/ContentView.swift
+++ b/MyJanken/MyJanken/ContentView.swift
@@ -17,7 +17,12 @@ struct ContentView: View {
             
             VStack {
                 Spacer()
-                JankenImageView(answerNumber: $answerNumber)
+                HStack{
+                    Spacer().frame(width: 50)
+                    JankenImageView(answerNumber: $answerNumber)
+                    Spacer().frame(width: 50)
+                }
+                Spacer()
                 JankenResultLabel(answerNumber: $answerNumber)
                 PlayJankenButton(answerNumber: $answerNumber)
             }


### PR DESCRIPTION
ジャンケンの画像が画面いっぱいすぎたので，左右にマージン追加しといた

上にしかSpacer効いてなかったので，間にも挟んどいた